### PR TITLE
Remove --run from `npm start`

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "skpm-build",
     "watch": "skpm-build --watch",
-    "start": "skpm-build --watch --run",
+    "start": "skpm-build --watch",
     "postinstall": "npm run build && skpm-link"
   },
   "devDependencies": {


### PR DESCRIPTION
Remove --run from `npm start` to avoid sketch to crash and scary beginners